### PR TITLE
Use graphql-core 3.3.0a3

### DIFF
--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -12,7 +12,7 @@ from collections.abc import MutableMapping
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, Union, cast
 
 from graphql.error import GraphQLError
-from graphql.execution import ExecutionResult, execute
+from graphql.execution import ExecutionResult, experimental_execute_incrementally
 from graphql.language import OperationType, parse
 from graphql.pyutils import AwaitableOrValue
 from graphql.type import GraphQLSchema, validate_schema
@@ -293,7 +293,7 @@ def get_response(
         if validation_errors:
             return ExecutionResult(data=None, errors=validation_errors)
 
-        execution_result = execute(
+        execution_result = experimental_execute_incrementally(
             schema,
             document,
             variable_values=params.variables,

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -11,8 +11,13 @@ from collections import namedtuple
 from collections.abc import MutableMapping
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, Union, cast
 
+from graphql import ExperimentalIncrementalExecutionResults
 from graphql.error import GraphQLError
-from graphql.execution import ExecutionResult, experimental_execute_incrementally
+from graphql.execution import (
+    ExecutionResult,
+    execute,
+    experimental_execute_incrementally,
+)
 from graphql.language import OperationType, parse
 from graphql.pyutils import AwaitableOrValue
 from graphql.type import GraphQLSchema, validate_schema
@@ -293,7 +298,7 @@ def get_response(
         if validation_errors:
             return ExecutionResult(data=None, errors=validation_errors)
 
-        execution_result = experimental_execute_incrementally(
+        execution_result = execute(
             schema,
             document,
             variable_values=params.variables,
@@ -307,6 +312,71 @@ def get_response(
 
     return execution_result
 
+def get_response_incrementally(
+    schema: GraphQLSchema,
+    params: GraphQLParams,
+    catch_exc: Type[BaseException],
+    allow_only_query: bool = False,
+    run_sync: bool = True,
+    validation_rules: Optional[Collection[Type[ASTValidationRule]]] = None,
+    max_errors: Optional[int] = None,
+    **kwargs,
+) -> Optional[AwaitableOrValue[Union[ExecutionResult, ExperimentalIncrementalExecutionResults]]]:
+    """
+    Same as get_response except calling the experimental feature of excecuting incrementally
+    """
+    # noinspection PyBroadException
+    try:
+        if not params.query:
+            raise HttpQueryError(400, "Must provide query string.")
+
+        # Sanity check query
+        if not isinstance(params.query, str):
+            raise HttpQueryError(400, "Unexpected query type.")
+
+        schema_validation_errors = validate_schema(schema)
+        if schema_validation_errors:
+            return ExecutionResult(data=None, errors=schema_validation_errors)
+
+        try:
+            document = parse(params.query)
+        except GraphQLError as e:
+            return ExecutionResult(data=None, errors=[e])
+        except Exception as e:
+            e = GraphQLError(str(e), original_error=e)
+            return ExecutionResult(data=None, errors=[e])
+
+        if allow_only_query:
+            operation_ast = get_operation_ast(document, params.operation_name)
+            if operation_ast:
+                operation = operation_ast.operation.value
+                if operation != OperationType.QUERY.value:
+                    raise HttpQueryError(
+                        405,
+                        f"Can only perform a {operation} operation"
+                        " from a POST request.",
+                        headers={"Allow": "POST"},
+                    )
+
+        validation_errors = validate(
+            schema, document, rules=validation_rules, max_errors=max_errors
+        )
+        if validation_errors:
+            return ExecutionResult(data=None, errors=validation_errors)
+
+        execution_result = experimental_execute_incrementally(
+            schema,
+            document,
+            variable_values=params.variables,
+            operation_name=params.operation_name,
+            is_awaitable=assume_not_awaitable if run_sync else None,
+            **kwargs,
+        )
+
+    except catch_exc:
+        return None
+
+    return execution_result
 
 def format_execution_result(
     execution_result: Optional[ExecutionResult],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from re import search
 from setuptools import find_packages, setup
 
 install_requires = [
-    "graphql-core>=3.2,<3.3",
+    "graphql-core==3.3.0a3",
     "typing-extensions>=4,<5",
 ]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,6 @@ def as_dicts(results: List[ExecutionResult]):
 
 
 class RepeatExecutionContext(ExecutionContext):
-    def execute_field(self, parent_type, source, field_nodes, path):
-        result = super().execute_field(parent_type, source, field_nodes, path)
+    def execute_field(self, parent_type, source, field_nodes, path, async_payload_record = None):
+        result = super().execute_field(parent_type, source, field_nodes, path, async_payload_record)
         return result * 2


### PR DESCRIPTION
### Summary
Pin the new alpha version to support defer and stream directives

Details: https://www.notion.so/zip-hq/How-to-add-defer-support-to-our-GraphQL-schema-d805fa8dfbf1423f8fb38a1e832c31b8?pvs=4#ea1893c955c44ffca1ffd416bf7dccf4

### Testing
`pytest tests --cov=graphql-server -vv`
<img width="1629" alt="Screenshot 2023-06-25 at 4 01 00 PM" src="https://github.com/graphql-python/graphql-server/assets/5653105/882343d4-56c4-4f0f-8ccd-44925cf377db">

